### PR TITLE
Fix: Update name of podspec to 'on_audio_query_ios' for fixing ios build

### DIFF
--- a/packages/on_audio_query_ios/ios/on_audio_query_ios.podspec
+++ b/packages/on_audio_query_ios/ios/on_audio_query_ios.podspec
@@ -3,7 +3,7 @@
 # Run `pod lib lint on_audio_query.podspec` to validate before publishing.
 #
 Pod::Spec.new do |s|
-  s.name             = 'on_audio_query'
+  s.name             = 'on_audio_query_ios'
   s.version          = '0.0.1'
   s.summary          = 'on_audio_query flutter plugin for ios.'
   s.description      = <<-DESC


### PR DESCRIPTION
iOS build can not be done with Xcode 14.2 and cocoapods 1.12.0

this is my log of Xcode version log with "flutter doctor -v":
Xcode - develop for iOS and macOS (Xcode 14.2)
    • Xcode at /Applications/Xcode.app/Contents/Developer
    • Build 14C18
    • CocoaPods version 1.12.0

Please update name of podspec to fix ios build.
Thanks.