### PR TITLE
Namespace and jave 1.8 version solved

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -1,5 +1,5 @@
 name: on_audio_query
-repository: https://github.com/LucJosin/on_audio_query
+repository: https://github.com/Sanjarbek17/on_audio_query
 
 packages:
   - packages/*

--- a/packages/on_audio_query/CHANGELOG.md
+++ b/packages/on_audio_query/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [[2.9.1]]
+
+## Fixes
+
+- **Fixed** namespace and java version. - [#154](https://github.com/LucJosin/on_audio_query/issues/154)
+
 ## [[2.9.0](https://github.com/LucJosin/on_audio_query/releases/tag/2.9.0)]
 
 ### Features

--- a/packages/on_audio_query/README.md
+++ b/packages/on_audio_query/README.md
@@ -1,9 +1,11 @@
 <div align=center>
 
-# on_audio_query
+# on_audio_query_forked
 [![Pub.dev](https://img.shields.io/pub/v/on_audio_query?color=9cf&label=Pub.dev&style=flat-square)](https://pub.dev/packages/on_audio_query)
 [![Platforms](https://img.shields.io/badge/Platforms-Android%20%7C%20IOS%20%7C%20Web-9cf?&style=flat-square)]()
 [![Languages](https://img.shields.io/badge/Languages-Dart%20%7C%20Kotlin%20%7C%20Swift-9cf?&style=flat-square)]()
+
+This is not an official plugin! This is a fork of the original plugin [flutter_audio_query](https://pub.dev/packages/flutter_audio_query) with some improvements and new features. <br>
 
 [Flutter](https://flutter.dev/) Plugin used to query audios/songs 🎶 infos [title, artist, album, etc..] from device storage. <br>
 

--- a/packages/on_audio_query/example/android/app/build.gradle
+++ b/packages/on_audio_query/example/android/app/build.gradle
@@ -35,7 +35,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.lucasjosino.on_audio_query_example"
-        minSdkVersion 16
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/on_audio_query/example/android/build.gradle
+++ b/packages/on_audio_query/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/packages/on_audio_query/example/lib/main.dart
+++ b/packages/on_audio_query/example/lib/main.dart
@@ -13,7 +13,7 @@ Copyright: © 2021, Lucas Josino. All rights reserved.
 */
 
 import 'package:flutter/material.dart';
-import 'package:on_audio_query/on_audio_query.dart';
+import 'package:on_audio_query_forked/on_audio_query.dart';
 
 void main() {
   runApp(

--- a/packages/on_audio_query/example/pubspec.yaml
+++ b/packages/on_audio_query/example/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  on_audio_query:
+  on_audio_query_forked:
     # When depending on this package from a real application you should use:
     #   on_audio_query: ^x.y.z
     # See https://dart.dev/tools/pub/dependencies#version-constraints

--- a/packages/on_audio_query/pubspec.yaml
+++ b/packages/on_audio_query/pubspec.yaml
@@ -5,7 +5,7 @@
 # ========
 name: on_audio_query_forked
 description: Flutter Plugin used to query audios/songs infos [title, artist, album, etc..] from device storage. This is not original plugin, this is a forked version.
-version: 2.9.0
+version: 2.9.1
 homepage: https://github.com/Sanjarbek17/on_audio_query/tree/main/packages/on_audio_query
 issue_tracker: https://github.com/LucJosin/on_audio_query/issues
 # pub.dev: https://pub.dev/packages/on_audio_query

--- a/packages/on_audio_query/pubspec.yaml
+++ b/packages/on_audio_query/pubspec.yaml
@@ -3,10 +3,10 @@
 # github: https://github.com/LucJosin
 # website: https://www.lucasjosino.com/
 # ========
-name: on_audio_query
-description: Flutter Plugin used to query audios/songs infos [title, artist, album, etc..] from device storage.
+name: on_audio_query_forked
+description: Flutter Plugin used to query audios/songs infos [title, artist, album, etc..] from device storage. This is not original plugin, this is a forked version.
 version: 2.9.0
-homepage: https://github.com/LucJosin/on_audio_query/tree/main/packages/on_audio_query
+homepage: https://github.com/Sanjarbek17/on_audio_query/tree/main/packages/on_audio_query
 issue_tracker: https://github.com/LucJosin/on_audio_query/issues
 # pub.dev: https://pub.dev/packages/on_audio_query
 topics:

--- a/packages/on_audio_query/pubspec.yaml
+++ b/packages/on_audio_query/pubspec.yaml
@@ -15,8 +15,6 @@ topics:
   - audioquery
   - on-audio-query
   - storage
-  - mediastore
-  - mpmediaquery
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/packages/on_audio_query/pubspec.yaml
+++ b/packages/on_audio_query/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   on_audio_query_platform_interface: ^1.7.0
   on_audio_query_web: ^1.6.0
   on_audio_query_ios: ^1.1.0
-  on_audio_query_android: ^1.1.0
+  on_audio_query_android_v1_8: ^1.1.1
 
   # Flutter
   flutter:

--- a/packages/on_audio_query_android/CHANGELOG.md
+++ b/packages/on_audio_query_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- Fixed some issues. Namespaces and java version.
+
 ## 1.1.0
 
 - See more [on_audio_query - CHANGELOG](https://github.com/LucJosin/on_audio_query/blob/main/on_audio_query/CHANGELOG.md).
@@ -13,3 +17,4 @@
 ## 1.0.0-prerelease.0 - [06.20.2022]
 
 - See more [on_audio_query - CHANGELOG](https://github.com/LucJosin/on_audio_query/blob/main/on_audio_query/CHANGELOG.md).
+

--- a/packages/on_audio_query_android/android/build.gradle
+++ b/packages/on_audio_query_android/android/build.gradle
@@ -27,11 +27,22 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 33
 
+    namespace 'com.lucasjosino.on_audio_query'
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
         minSdkVersion 16
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
     }
 }
 

--- a/packages/on_audio_query_android/pubspec.yaml
+++ b/packages/on_audio_query_android/pubspec.yaml
@@ -3,13 +3,12 @@
 # github: https://github.com/LucJosin
 # website: https://www.lucasjosino.com/
 # ========
-name: on_audio_query_android
+name: on_audio_query_android_v1_8
 description: Android implementation of the on_audio_query plugin.
-version: 1.1.0
-homepage: https://github.com/LucJosin/on_audio_query/tree/main/packages/on_audio_query_android
+version: 1.1.1
+homepage: https://github.com/Sanjarbek17/on_audio_query/tree/main/packages/on_audio_query_android
 # pub.dev: https://pub.dev/packages/on_audio_query
 # pub.dev (Android): https://pub.dev/packages/on_audio_query_android
-
 environment:
   sdk: ">=2.17.0 <4.0.0"
   flutter: ">=2.5.0"


### PR DESCRIPTION
This is not for merging becuase since owner stopped updating this package This pull request for those who want to use this package. I have published new package that solves the issues of this package. If you want to use it, you can on_audio_query_forked: ^2.9.1 add this on your pubscep file.