### PR TITLE
Add namespace to  build.gradle

### DIFF
--- a/packages/on_audio_query_android/android/build.gradle
+++ b/packages/on_audio_query_android/android/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 33
+    namespace = "com.lucasjosino.on_audio_query"
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
Add namespace to  build.gradle to prevent compilation errors

Fixes #162 